### PR TITLE
new license page

### DIFF
--- a/root/css/license-info.css
+++ b/root/css/license-info.css
@@ -1,0 +1,50 @@
+.legal-doc p {
+  font-family: "Times New Roman", Georgia, Serif;
+  padding: 0;
+  margin: 0;
+}
+
+.legal-doc .section {
+  padding-top: 2.5em;
+}
+
+.legal-doc .section:not(.ignore) > *:not(:last-child):not(.ignore) {
+  padding-bottom: 1.5em;
+}
+
+.legal-doc .ignore {
+  padding-bottom: 0;
+}
+
+.legal-doc .indent {
+  padding-left: 1.25em;
+}
+
+.legal-doc .center {
+  text-align: center;
+}
+
+.legal-doc .bold {
+  font-weight: bold;
+}
+
+.legal-doc .slant {
+  font-style: italic;
+}
+
+.legal-doc .und {
+  text-decoration: underline;
+}
+
+.legal-doc ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.legal-doc ul.rom {
+  list-style-type: upper-roman;
+}
+
+.legal-doc ul.lat {
+  list-style-type: upper-latin;
+}

--- a/src/java/edu/colorado/phet/website/content/about/HTMLLicensingPanel.html
+++ b/src/java/edu/colorado/phet/website/content/about/HTMLLicensingPanel.html
@@ -4,18 +4,175 @@
       xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd" xml:lang="en"
       lang="en">
 <head>
-    <title>[PREVIEW] HTMLLicensingPanel</title>
+    <title>PhET Licenses</title>
     <wicket:remove>
-        <link rel="stylesheet" type="text/css" href="../../../../../../../../root/css/preview.css"/>
+        <link rel="stylesheet" type="text/css" href="../../../../../../../../root/css/license-info.css"/>
     </wicket:remove>
 </head>
 <body>
 
 <wicket:panel>
     <div wicket:message="dir:language.dir" class="html-licensing-panel standard-content">
-        <p wicket:id="html-licensing-comingSoon">
-            Information coming soon, please contact <a href="mailto:phethelp@colorado.edu">phethelp@colorado.edu</a>.
-        </p>
+	<div class="legal-doc">
+	  <div id="agreement-header" class="section ignore center bold">
+	    <p>PhET SOFTWARE AGREEMENT</p>
+	    <p>Terms of Use and Privacy Policy for PhET's collection of HTML Simulations</p>
+	    <p>(Version 1)</p>
+	    <p>University of Colorado Boulder</p>
+	  </div>
+
+	  <div id="agreement-index" class="section">
+	    <p>In this document:</p>
+	    <ul class="rom">
+	      <li>Overview</li>
+	      <li>Software License Information</li>
+	      <ul class="lat">
+		<li>‘PhET Regulat HTML Simulation File’: Creative Commons Attribution 4.0</li>
+		<li>‘PhET HTML Simulation Source Code’: GNU General Public License Version 3</li>
+		<li>‘PhET HTML Common Source Code’: MIT License</li>
+		<li>Attribution</li>
+		<li>Donations</li>
+		<li>Third Party Software Credits</li>
+		<li>Alternative Licensing Options</li>
+	      </ul>
+	      <li>PhET Name and Logo Trademark</li>
+	      <li>Privacy Policy</li>
+	      <ul class="lat">
+		<li>Commitment to Individual Privacy</li>
+		<li>Information Collected</li>
+		<li>Information Security</li>
+		<li>Information Sharing</li>
+		<li>Colorado Open Records Act</li>
+		<li>Additional privacy terms apply when PhET is used with the Microsoft Office Mix Service</li>
+	      </ul>
+	      <li>Disclaimer</li>
+	      <li>Contact Us</li>
+	    </ul>
+	  </div>
+	  
+	  <div id="agreement-I" class="section">
+	    <p class="bold">I. OVERVIEW</p>
+	  
+	    <p>This PhET Software Agreement (“<b>Agreement</b>”) pertains to the collection of HTML simulations developed by the PhET Interactive Simulations Project at the University of Colorado Boulder (“<b>PhET</b>”). PhET currently offers three different software licensing options, which are detailed in Section II(A), II(B) and II(C) below, to the users of its HTML simulations.</p>
+	  
+	    <p>This Agreement and the licenses specified below do <i>not</i> permit the licensing of PhET’s Java or Flash simulations. Information regarding PhET’s Java or Flash simulations is available at <a href="http://phet.colorado.edu">http://phet.colorado.edu</a>.</p>
+	  </div>
+
+	  <div id="agreement-II" class="section">
+	    <p class="bold">II. SOFTWARE LICENSE OPTIONS</p>
+	  
+	    <p id="agreement-II-A" class="bold indent">A. <u>PhET Regular HTML Simulation File: Creative Commons Attribution 4.0</u></p>
+
+	    <p><b>“PhET Regular HTML Simulation File”</b> means an individual minified HTML simulation file where PhET HTML Simulation Source Code (PhET HTML Simulation Source Code is defined below) assets and PhET HTML Common Source Code (PhET HTML Common Source Code is defined below) assets are combined into a single, minified HTML file that can be run in a browser, or downloaded and launched, without any other requirements.</p>
+
+	    <p>PhET licenses PhET Regular HTML Simulation Files individually under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 License</a> (“<b>CC BY 4.0</b>”). The full text of the Creative Commons Attribution 4.0 license is available here: <a href="http://creativecommons.org/licenses/by/4.0/legalcode">http://creativecommons.org/licenses/by/4.0/legalcode</a>.</p>
+	    
+	    <p>The collection of PhET Regular HTML Simulation Files are available to run or download from <a href="http://phet.colorado.edu">http://phet.colorado.edu</a>.</p>
+	    
+	    <img width="200" src="http://www.teqsa.gov.au/sites/default/files/cc_by_logo.jpg" />
+	    
+	    <p class="ignore bold slant">What does the CC BY 4.0 License mean?</p>
+	    <p>PhET Regular HTML Simulation Files may be freely used and/or redistributed by third parties (e.g. students, educators, school districts, museums, publishers, vendors, etc.) for non-commercial or commercial purposes.</p>
+	    
+	    <p>Any use of a PhET Regular HTML Simulation File under the CC BY 4.0 requires the following attribution: “PhET Interactive Simulations, University of Colorado Boulder, <a href="http://phet.colorado.edu">http://phet.colorado.edu</a>.”</p>
+	    
+	    <p>The CC-BY-4.0 license does <i>not</i> apply to the PhET name and PhET logo, which are trademarks of The Regents of the University of Colorado, a body corporate. See Section III below for additional information regarding how to use legally the PhET name and logo.</p>
+	    
+	    <p id="agreement-II-B" class="bold indent">B. <u>‘PhET HTML Simulation Source Code’: GNU General Public License Version 3</u></p>
+	    
+	    <p><b>“PhET HTML Simulation Source Code”</b> is the collection of original simulation specific assets used by a PhET simulation, including but not limited to source code (JavaScript/HTML/CSS), images, audio and text.</p>
+	    
+	    <p>PhET licenses PhET HTML Simulation Source Code under the <a href="https://www.gnu.org/licenses/gpl.html">GNU General Public License Version 3</a> (“<b>GPLv3</b>”). The full text of the GPLv3 is available here: <a href="https://www.gnu.org/licenses/gpl.html">https://www.gnu.org/licenses/gpl.html</a></p>
+	    
+	    <p>The simulation-specific PhET HTML Simulation Source Code repositories can be accessed at <a href="http://github.com/phetsims">http://github.com/phetsims</a>. The license file within the specific PhET HTML Simulation Source Code repository specifies whether it is available under the GPLv3.</p>
+	    
+	    <img width="200" src="http://zdnet2.cbsistatic.com/hub/i/2014/10/04/fafd72de-4ba6-11e4-b6a0-d4ae52e95e57/00c810580295cc623a7c38f649120fd5/gplv3-logo-red.png" />
+	    
+	    <p class="ignore bold slant">What does the GPLv3 mean?</p>
+	    <p>The simulation-specific source code for each PhET HTML Simulation Source Code is available for use and/or modification. Anyone may access to the source code and make modifications. If a user makes any changes whatsoever to the source code of the software, then the changes must be made publicly available by the party that makes the changes.</p>
+	    
+	    <p id="agreement-II-C" class="bold indent">C. <u>‘PhET HTML Common Source Code’: MIT License</u></p>
+	
+	    <p><b>“PhET HTML Simulation Source Code”</b> is the collection of original simulation specific assets used by a PhET simulation, including but not limited to source code (JavaScript/HTML/CSS), images, audio and text.</p>
+	    
+	    <p>PhET licenses PhET HTML Simulation Source Code under the <a href="http://opensource.org/licenses/MIT">MIT Licsnse</a>. The full text of the MIT License is available here: <a href="http://opensource.org/licenses/MIT">http://opensource.org/licenses/MIT</a></p>
+	    
+	    <p>PhET HTML Common Source Code can be accessed at <a href="http://github.com/phetsims">http://github.com/phetsims</a>. The license file within the specific PhET HTML Common Source Code repository specifies whether it is available under the MIT License.</p>
+	    
+	    <p class="ignore bold slant">What does using the MIT License mean?</p>
+	    <p>The common source code libraries for PhET HTML Common Source Code are available for use and/or modification. For directions about how to access the source code, go to: <a href="http://phet.colorado.edu/about/source-code.php">http://phet.colorado.edu/about/source-code.php</a>. Anyone can have access to the source code and make modifications. The copyright and permission notice must be included in all copies or copies of substantial portions of the Software.</p>
+	    
+	    <p id="agreement-II-D" class="bold indent">D. <u>Donations</u></p>
+	    
+	    <p>PhET requires ongoing donations, sponsorships and grant funding in order to support the project, continue the development of new simulations, and maintain existing simulations.</p>
+	    
+	    <p>Commercial users are highly encouraged to support the project and its mission with a tax-deductible donation to PhET. For more information, email <a href="mailto:phethelp@colorado.edu">phethelp@colorado.edu</a> or visit <a href="http://phet.colorado.edu/en/donate">http://phet.colorado.edu/en/donate</a>.</p>
+	    
+	    <p id="agreement-II-E" class="bold indent">E. <u>Third Party Software Credits</u></p>
+	    
+	    <p>PhET simulations use third-party software. A complete list of third-party libraries used, the developers, and the associated licenses is listed at the top of each “PhET Regular HTML Simulation File”, using the browser’s view source tool.</p>
+	    
+	    <p id="agreement-II-F" class="bold indent">F. <u>Alternative License Options</u></p>
+	    
+	    <p>Permissions beyond the scope of these licenses, including licensing for PhET Enhanced HTML Simulation Files or source code assets not identified as openly-licensed in their license files, may be available upon request. Please contact us at <a href="mailto:phethelp@colorado.edu">phethelp@colorado.edu</a>.</p>
+	  </div>
+	  
+	  <div id="agreement-III" class="section">
+	    <p class="bold">III. PHET NAME AND LOGO TRADEMARK</p>
+	    
+	    <p>The PhET name and PhET logo are trademarks of The Regents of the University of Colorado, a body corporate. Permission is granted to use the PhET name and PhET logo only for attribution purposes. Use of the PhET name and/or PhET logo for promotional, marketing, or advertising purposes requires a separate license agreement from the University of Colorado. Contact <a href="mailto:phethelp@colorado.edu">phethelp@colorado.edu</a> to discuss trademark licensing options.</p>
+	  </div>
+	  
+	  <div id="agreement-IV" class="section">
+	    <p class="bold">IV. PRIVACY POLICY</p>
+	    
+	    <p id="agreement-IV-A" class="bold indent">A. <u>Commitment to Individual Privacy</u></p>
+	    
+	    <p>The University of Colorado and the PhET Interactive Simulations Project support the protection of individual privacy, and ensuring the confidentiality of information provided by its employees, students, visitors, and resource users.</p>
+	    
+	    <p id="agreement-IV-B" class="bold indent">B. <u>Information Collected</u></p>
+	    
+	    <p>It is the policy and practice of the University  to collect the least amount of personally identifiable information necessary to fulfill its required duties and responsibilities, complete a particular transaction, deliver services, or as required by law.  This applies to the collection of all personally identifiable information regardless of source or medium.</p>
+	    
+	    <p>Users may choose whether or not to provide personally identifiable information to the University and PhET via the PhET website.</p>
+	    
+	    <p>In order to document the amount of use of PhET simulations and to provide the best services to our users, PhET collects non-personally identifying information through the use of Google Analytics in each PhET Regular HTML Simulation File. When the simulation is opened, information is collected via Google Analytics’ standard web statistics services. As of July 8, 2014 Google Analytics Terms of Service are located here <a href="http://www.google.com/analytics/terms/us.html">http://www.google.com/analytics/terms/us.html</a>.</p>
+	    
+	    <p>In addition, PhET uses “cookies,” which are small text files stored on the user’s device, to help operate its website and collect information about online activity.</p>
+	    
+	    <p id="agreement-IV-C" class="bold indent">C. <u>Information Security</u></p>
+	    
+	    <p>The PhET has in place appropriate security measures to protect against the unauthorized use or access of its data. Such measures include internal review of data collection, storage, and processing practices and security measures, as well as physical security measures to guard against unauthorized access to systems where data is stored.</p>
+	    
+	    <p id="agreement-IV-D" class="bold indent">D. <u>Information Sharing</u></p>
+	    
+	    <p>Access to information collected through the use of PhET simulations is limited to those employees, contractors, and agents who need to know that information in order to operate, develop, or improve our services. PhET may report a summary of this information (in aggregate) to other organizations and individuals for grant reporting purposes, or in published articles to document PhET’s wide-spread use. No personally-identifying information is distributed. PhET requires third parties to whom it discloses information to protect the information in accordance with this policy and applicable law. In addition, PhET may disclose information to third parties when such disclosure is required or permitted by law.</p>
+	    
+	    <p id="agreement-IV-E" class="bold indent">E. <u>Colorado Open Records Act</u></p>
+	    
+	    <p>The University of Colorado and the PhET project are subject to the Colorado Open Records Act, C.R.S § 24-72-101 <i>et seq</i>. The Colorado Open Records Act requires that all records maintained by the University and PhET be available for public inspection except as otherwise provided by law. Personal identifying information collected by PhET may be subject to public inspection and copying unless protected by state or federal law.</p>
+	    
+	    <p id="agreement-IV-F" class="bold indent">F. <u>Additional Privacy Terms Apply When PhET is Used with the Microsoft Office Mix Service</u></p>
+	    
+	    <p>The app for Office Mix will share information with Microsoft about how the users interact with it, such as whether the app loaded successfully, any content that is displayed in the app, and any information entered in the app. Microsoft may combine this information with other information to provide the Office Mix service in accordance with the statement on <a href="http://aka.ms/privacy-onlinelearning">Privacy &amp; Cookies</a> for Office Mix. By using this app, the user consents to the app sharing information with Microsoft for these purposes.</p>
+	  </div>
+
+	  <div id="agreement-V" class="section">
+	    <p class="bold">V. DISCLAIMER</p>
+	    
+	    <p>This software and the information contained therein is provided as a public service, with the understanding that neither the University of Colorado nor PhET makes any warranties, either express or implied, concerning the accuracy, completeness, reliability, or suitability of this software and information.</p>
+	    
+	    <p>By using this software, you assume all risks associated with such use, including but not limited to the risk of any damage to your computer, software, or data.  In no event shall the University or PhET be liable for any direct, indirect, punitive, special, incidental, or consequential damages (including, without limitation, lost revenues or profits or lost or damaged data) arising from the user’s use of this software.</p>
+	    
+	    <p>Neither the University nor PhET are a law firm and do not provide legal services or legal advice. Using the simulations under the licensing options in this agreement does not create a lawyer-client or other relationship. Any information provided to the user regarding the licensing options is intended to provide general guidance to the user. If the user requires legal assistance, the user should contact a law firm or a lawyer.</p>
+	  </div>
+	  
+	  <div id="agreement-VI" class="section">
+	    <p class="bold">VI. CONTACT US</p>
+	    
+	    <p>Please send comments, questions, or concerns regarding this software agreement to <a href="mailto:phethelp@colorado.edu">phethelp@colorado.edu</a>. Please do not send attachments with the message.</p>
+	  </div>
+	</div>
     </div>
 </wicket:panel>
 


### PR DESCRIPTION
@aaronsamuel137 , I believe these changes are the ones required to display the new license info. Please let me know if everything looks good compiled (I still haven't been able to host a VM for it).

Also, what should I do about hosting our own images instead of taking them from outside as on [line 72](https://github.com/phetsims/website/compare/newLicense?expand=1#diff-5c20b567e7e8491ec132ebd39a275d72R72) and [line 89](https://github.com/phetsims/website/compare/newLicense?expand=1#diff-5c20b567e7e8491ec132ebd39a275d72R89)?